### PR TITLE
Adjust requirements to allow Neos 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "GPL-3.0-or-later"
     ],
     "require": {
-        "neos/fusion": "^7.3 || ^8.0"
+        "neos/fusion": "^7.3 || ^8.0 || ^9.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I adjusted the requirements to allow `neos/fusion: 9.0`. I also allowed `dev-master` so it can be installed in current test projects before the 9.0 release. Checked and tested it and it works fine.