### PR TITLE
BUGFIX: Dont use http request to calculate sha1 or get contents current server

### DIFF
--- a/Classes/Service/FileService.php
+++ b/Classes/Service/FileService.php
@@ -39,12 +39,13 @@ class FileService
             $uri = sprintf('resource://%s/Public/%s%s', $package, $folder, $uri);
         }
 
-        if (str_starts_with($uri, 'resource://')) {
-            $uri = $this->resourceManager->getPublicPackageResourceUriByPath($uri);
-        }
-
         if ($inline) {
             return file_get_contents($uri) ?: '';
+        }
+
+        $flowResourcePathOrUri = $uri;
+        if (str_starts_with($flowResourcePathOrUri, 'resource://')) {
+            $uri = $this->resourceManager->getPublicPackageResourceUriByPath($flowResourcePathOrUri);
         }
 
         if ($hashLength <= 0) {
@@ -53,7 +54,7 @@ class FileService
 
         $hashValue = '';
         try {
-            $hashValue = sha1_file($uri);
+            $hashValue = sha1_file($flowResourcePathOrUri);
             if (strlen($hashValue) > $hashLength) {
                 $hashValue = substr($hashValue, 0, $hashLength);
             }


### PR DESCRIPTION

Aside from extra work for the server due to avoidable request this is especially required to not crash the builtin php server via `flow server:run` which otherwise times out attempting to get `sha1_file` because of the recursion.

So in case a hash should be calculated, we use 

```php
sha1_file("resource://Vendor.Site/Public/JavaScript/Foo.js");
```

instead of

```php
sha1_file("127.0.0.1:8081/_Resources/Static/Packages/Vendor.Site/JavaScript/Foo.js");
```

Additionally this change fixes the same problem for `$include=true` and uses `file_get_contents()` with the flow resource path.

Note: Using php methods on `resource://` works because Flow registers a stream wrapper to the underlying filesystem stream.